### PR TITLE
Extend graphql and on-disk resources to include all productlisting data

### DIFF
--- a/internal/genpyxis/fragments.graphql
+++ b/internal/genpyxis/fragments.graphql
@@ -23,9 +23,30 @@ fragment ProductListingSupportedFields on ProductListing {
     url
   }
   legal {
-    description
     license_agreement_url
     privacy_policy_url
+  }
+  linked_resources {
+    title
+    type
+    description
+    url
+  }
+  faqs {
+    answer
+    question
+  }
+  search_aliases {
+    key
+    value
+  }
+  functional_categories
+  features {
+    title
+    description
+  }
+  quick_start_configuration {
+    instructions
   }
 }
 

--- a/internal/genpyxis/generated.go
+++ b/internal/genpyxis/generated.go
@@ -1325,6 +1325,36 @@ func (v *MutateProductListingCommonResponseDataProductListing) GetLegal() *Produ
 	return v.ProductListingSupportedFields.Legal
 }
 
+// GetLinked_resources returns MutateProductListingCommonResponseDataProductListing.Linked_resources, and is useful for accessing the field via an interface.
+func (v *MutateProductListingCommonResponseDataProductListing) GetLinked_resources() []*ProductListingSupportedFieldsLinked_resourcesLinkedResourcesItems {
+	return v.ProductListingSupportedFields.Linked_resources
+}
+
+// GetFaqs returns MutateProductListingCommonResponseDataProductListing.Faqs, and is useful for accessing the field via an interface.
+func (v *MutateProductListingCommonResponseDataProductListing) GetFaqs() []*ProductListingSupportedFieldsFaqsFAQSItems {
+	return v.ProductListingSupportedFields.Faqs
+}
+
+// GetSearch_aliases returns MutateProductListingCommonResponseDataProductListing.Search_aliases, and is useful for accessing the field via an interface.
+func (v *MutateProductListingCommonResponseDataProductListing) GetSearch_aliases() []*ProductListingSupportedFieldsSearch_aliasesSearchAliasesItems {
+	return v.ProductListingSupportedFields.Search_aliases
+}
+
+// GetFunctional_categories returns MutateProductListingCommonResponseDataProductListing.Functional_categories, and is useful for accessing the field via an interface.
+func (v *MutateProductListingCommonResponseDataProductListing) GetFunctional_categories() []string {
+	return v.ProductListingSupportedFields.Functional_categories
+}
+
+// GetFeatures returns MutateProductListingCommonResponseDataProductListing.Features, and is useful for accessing the field via an interface.
+func (v *MutateProductListingCommonResponseDataProductListing) GetFeatures() []*ProductListingSupportedFieldsFeaturesFeaturesItems {
+	return v.ProductListingSupportedFields.Features
+}
+
+// GetQuick_start_configuration returns MutateProductListingCommonResponseDataProductListing.Quick_start_configuration, and is useful for accessing the field via an interface.
+func (v *MutateProductListingCommonResponseDataProductListing) GetQuick_start_configuration() *ProductListingSupportedFieldsQuick_start_configurationQuickStartConfiguration {
+	return v.ProductListingSupportedFields.Quick_start_configuration
+}
+
 func (v *MutateProductListingCommonResponseDataProductListing) UnmarshalJSON(b []byte) error {
 
 	if string(b) == "null" {
@@ -1376,6 +1406,18 @@ type __premarshalMutateProductListingCommonResponseDataProductListing struct {
 	Support *ProductListingSupportedFieldsSupport `json:"support"`
 
 	Legal *ProductListingSupportedFieldsLegal `json:"legal"`
+
+	Linked_resources []*ProductListingSupportedFieldsLinked_resourcesLinkedResourcesItems `json:"linked_resources"`
+
+	Faqs []*ProductListingSupportedFieldsFaqsFAQSItems `json:"faqs"`
+
+	Search_aliases []*ProductListingSupportedFieldsSearch_aliasesSearchAliasesItems `json:"search_aliases"`
+
+	Functional_categories []string `json:"functional_categories"`
+
+	Features []*ProductListingSupportedFieldsFeaturesFeaturesItems `json:"features"`
+
+	Quick_start_configuration *ProductListingSupportedFieldsQuick_start_configurationQuickStartConfiguration `json:"quick_start_configuration"`
 }
 
 func (v *MutateProductListingCommonResponseDataProductListing) MarshalJSON() ([]byte, error) {
@@ -1402,6 +1444,12 @@ func (v *MutateProductListingCommonResponseDataProductListing) __premarshalJSON(
 	retval.Cert_projects = v.ProductListingSupportedFields.Cert_projects
 	retval.Support = v.ProductListingSupportedFields.Support
 	retval.Legal = v.ProductListingSupportedFields.Legal
+	retval.Linked_resources = v.ProductListingSupportedFields.Linked_resources
+	retval.Faqs = v.ProductListingSupportedFields.Faqs
+	retval.Search_aliases = v.ProductListingSupportedFields.Search_aliases
+	retval.Functional_categories = v.ProductListingSupportedFields.Functional_categories
+	retval.Features = v.ProductListingSupportedFields.Features
+	retval.Quick_start_configuration = v.ProductListingSupportedFields.Quick_start_configuration
 	return &retval, nil
 }
 
@@ -1914,6 +1962,17 @@ type ProductListingSupportedFields struct {
 	// This field is required when the product listing is published.
 	Support *ProductListingSupportedFieldsSupport `json:"support"`
 	Legal   *ProductListingSupportedFieldsLegal   `json:"legal"`
+	// This field is required when the product listing is published.
+	Linked_resources []*ProductListingSupportedFieldsLinked_resourcesLinkedResourcesItems `json:"linked_resources"`
+	// FAQ section for the catalog page.
+	Faqs []*ProductListingSupportedFieldsFaqsFAQSItems `json:"faqs"`
+	// List of search aliases for Solr.
+	Search_aliases []*ProductListingSupportedFieldsSearch_aliasesSearchAliasesItems `json:"search_aliases"`
+	// This field is required when the product listing is published.
+	Functional_categories []string `json:"functional_categories"`
+	// Features section for the catalog page.
+	Features                  []*ProductListingSupportedFieldsFeaturesFeaturesItems                          `json:"features"`
+	Quick_start_configuration *ProductListingSupportedFieldsQuick_start_configurationQuickStartConfiguration `json:"quick_start_configuration"`
 }
 
 // GetId returns ProductListingSupportedFields.Id, and is useful for accessing the field via an interface.
@@ -1963,6 +2022,36 @@ func (v *ProductListingSupportedFields) GetLegal() *ProductListingSupportedField
 	return v.Legal
 }
 
+// GetLinked_resources returns ProductListingSupportedFields.Linked_resources, and is useful for accessing the field via an interface.
+func (v *ProductListingSupportedFields) GetLinked_resources() []*ProductListingSupportedFieldsLinked_resourcesLinkedResourcesItems {
+	return v.Linked_resources
+}
+
+// GetFaqs returns ProductListingSupportedFields.Faqs, and is useful for accessing the field via an interface.
+func (v *ProductListingSupportedFields) GetFaqs() []*ProductListingSupportedFieldsFaqsFAQSItems {
+	return v.Faqs
+}
+
+// GetSearch_aliases returns ProductListingSupportedFields.Search_aliases, and is useful for accessing the field via an interface.
+func (v *ProductListingSupportedFields) GetSearch_aliases() []*ProductListingSupportedFieldsSearch_aliasesSearchAliasesItems {
+	return v.Search_aliases
+}
+
+// GetFunctional_categories returns ProductListingSupportedFields.Functional_categories, and is useful for accessing the field via an interface.
+func (v *ProductListingSupportedFields) GetFunctional_categories() []string {
+	return v.Functional_categories
+}
+
+// GetFeatures returns ProductListingSupportedFields.Features, and is useful for accessing the field via an interface.
+func (v *ProductListingSupportedFields) GetFeatures() []*ProductListingSupportedFieldsFeaturesFeaturesItems {
+	return v.Features
+}
+
+// GetQuick_start_configuration returns ProductListingSupportedFields.Quick_start_configuration, and is useful for accessing the field via an interface.
+func (v *ProductListingSupportedFields) GetQuick_start_configuration() *ProductListingSupportedFieldsQuick_start_configurationQuickStartConfiguration {
+	return v.Quick_start_configuration
+}
+
 // ProductListingSupportedFieldsContactsContactsItems includes the requested fields of the GraphQL type ContactsItems.
 type ProductListingSupportedFieldsContactsContactsItems struct {
 	Email_address string `json:"email_address"`
@@ -1993,15 +2082,43 @@ func (v *ProductListingSupportedFieldsDescriptions) GetLong() string { return v.
 // GetShort returns ProductListingSupportedFieldsDescriptions.Short, and is useful for accessing the field via an interface.
 func (v *ProductListingSupportedFieldsDescriptions) GetShort() string { return v.Short }
 
+// ProductListingSupportedFieldsFaqsFAQSItems includes the requested fields of the GraphQL type FAQSItems.
+// The GraphQL type's documentation follows.
+//
+// This field is required when the product listing is published.
+type ProductListingSupportedFieldsFaqsFAQSItems struct {
+	Answer   string `json:"answer"`
+	Question string `json:"question"`
+}
+
+// GetAnswer returns ProductListingSupportedFieldsFaqsFAQSItems.Answer, and is useful for accessing the field via an interface.
+func (v *ProductListingSupportedFieldsFaqsFAQSItems) GetAnswer() string { return v.Answer }
+
+// GetQuestion returns ProductListingSupportedFieldsFaqsFAQSItems.Question, and is useful for accessing the field via an interface.
+func (v *ProductListingSupportedFieldsFaqsFAQSItems) GetQuestion() string { return v.Question }
+
+// ProductListingSupportedFieldsFeaturesFeaturesItems includes the requested fields of the GraphQL type FeaturesItems.
+// The GraphQL type's documentation follows.
+//
+// This field is required when the product listing is published.
+type ProductListingSupportedFieldsFeaturesFeaturesItems struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+}
+
+// GetTitle returns ProductListingSupportedFieldsFeaturesFeaturesItems.Title, and is useful for accessing the field via an interface.
+func (v *ProductListingSupportedFieldsFeaturesFeaturesItems) GetTitle() string { return v.Title }
+
+// GetDescription returns ProductListingSupportedFieldsFeaturesFeaturesItems.Description, and is useful for accessing the field via an interface.
+func (v *ProductListingSupportedFieldsFeaturesFeaturesItems) GetDescription() string {
+	return v.Description
+}
+
 // ProductListingSupportedFieldsLegal includes the requested fields of the GraphQL type Legal.
 type ProductListingSupportedFieldsLegal struct {
-	Description           string `json:"description"`
 	License_agreement_url string `json:"license_agreement_url"`
 	Privacy_policy_url    string `json:"privacy_policy_url"`
 }
-
-// GetDescription returns ProductListingSupportedFieldsLegal.Description, and is useful for accessing the field via an interface.
-func (v *ProductListingSupportedFieldsLegal) GetDescription() string { return v.Description }
 
 // GetLicense_agreement_url returns ProductListingSupportedFieldsLegal.License_agreement_url, and is useful for accessing the field via an interface.
 func (v *ProductListingSupportedFieldsLegal) GetLicense_agreement_url() string {
@@ -2011,6 +2128,58 @@ func (v *ProductListingSupportedFieldsLegal) GetLicense_agreement_url() string {
 // GetPrivacy_policy_url returns ProductListingSupportedFieldsLegal.Privacy_policy_url, and is useful for accessing the field via an interface.
 func (v *ProductListingSupportedFieldsLegal) GetPrivacy_policy_url() string {
 	return v.Privacy_policy_url
+}
+
+// ProductListingSupportedFieldsLinked_resourcesLinkedResourcesItems includes the requested fields of the GraphQL type LinkedResourcesItems.
+type ProductListingSupportedFieldsLinked_resourcesLinkedResourcesItems struct {
+	Title       string `json:"title"`
+	Type        string `json:"type"`
+	Description string `json:"description"`
+	Url         string `json:"url"`
+}
+
+// GetTitle returns ProductListingSupportedFieldsLinked_resourcesLinkedResourcesItems.Title, and is useful for accessing the field via an interface.
+func (v *ProductListingSupportedFieldsLinked_resourcesLinkedResourcesItems) GetTitle() string {
+	return v.Title
+}
+
+// GetType returns ProductListingSupportedFieldsLinked_resourcesLinkedResourcesItems.Type, and is useful for accessing the field via an interface.
+func (v *ProductListingSupportedFieldsLinked_resourcesLinkedResourcesItems) GetType() string {
+	return v.Type
+}
+
+// GetDescription returns ProductListingSupportedFieldsLinked_resourcesLinkedResourcesItems.Description, and is useful for accessing the field via an interface.
+func (v *ProductListingSupportedFieldsLinked_resourcesLinkedResourcesItems) GetDescription() string {
+	return v.Description
+}
+
+// GetUrl returns ProductListingSupportedFieldsLinked_resourcesLinkedResourcesItems.Url, and is useful for accessing the field via an interface.
+func (v *ProductListingSupportedFieldsLinked_resourcesLinkedResourcesItems) GetUrl() string {
+	return v.Url
+}
+
+// ProductListingSupportedFieldsQuick_start_configurationQuickStartConfiguration includes the requested fields of the GraphQL type QuickStartConfiguration.
+type ProductListingSupportedFieldsQuick_start_configurationQuickStartConfiguration struct {
+	Instructions string `json:"instructions"`
+}
+
+// GetInstructions returns ProductListingSupportedFieldsQuick_start_configurationQuickStartConfiguration.Instructions, and is useful for accessing the field via an interface.
+func (v *ProductListingSupportedFieldsQuick_start_configurationQuickStartConfiguration) GetInstructions() string {
+	return v.Instructions
+}
+
+// ProductListingSupportedFieldsSearch_aliasesSearchAliasesItems includes the requested fields of the GraphQL type SearchAliasesItems.
+type ProductListingSupportedFieldsSearch_aliasesSearchAliasesItems struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// GetKey returns ProductListingSupportedFieldsSearch_aliasesSearchAliasesItems.Key, and is useful for accessing the field via an interface.
+func (v *ProductListingSupportedFieldsSearch_aliasesSearchAliasesItems) GetKey() string { return v.Key }
+
+// GetValue returns ProductListingSupportedFieldsSearch_aliasesSearchAliasesItems.Value, and is useful for accessing the field via an interface.
+func (v *ProductListingSupportedFieldsSearch_aliasesSearchAliasesItems) GetValue() string {
+	return v.Value
 }
 
 // ProductListingSupportedFieldsSupport includes the requested fields of the GraphQL type Support.
@@ -2455,9 +2624,30 @@ fragment ProductListingSupportedFields on ProductListing {
 		url
 	}
 	legal {
-		description
 		license_agreement_url
 		privacy_policy_url
+	}
+	linked_resources {
+		title
+		type
+		description
+		url
+	}
+	faqs {
+		answer
+		question
+	}
+	search_aliases {
+		key
+		value
+	}
+	functional_categories
+	features {
+		title
+		description
+	}
+	quick_start_configuration {
+		instructions
 	}
 }
 `
@@ -2699,9 +2889,30 @@ fragment ProductListingSupportedFields on ProductListing {
 		url
 	}
 	legal {
-		description
 		license_agreement_url
 		privacy_policy_url
+	}
+	linked_resources {
+		title
+		type
+		description
+		url
+	}
+	faqs {
+		answer
+		question
+	}
+	search_aliases {
+		key
+		value
+	}
+	functional_categories
+	features {
+		title
+		description
+	}
+	quick_start_configuration {
+		instructions
 	}
 }
 `
@@ -2937,9 +3148,30 @@ fragment ProductListingSupportedFields on ProductListing {
 		url
 	}
 	legal {
-		description
 		license_agreement_url
 		privacy_policy_url
+	}
+	linked_resources {
+		title
+		type
+		description
+		url
+	}
+	faqs {
+		answer
+		question
+	}
+	search_aliases {
+		key
+		value
+	}
+	functional_categories
+	features {
+		title
+		description
+	}
+	quick_start_configuration {
+		instructions
 	}
 }
 `
@@ -3008,9 +3240,30 @@ fragment ProductListingSupportedFields on ProductListing {
 		url
 	}
 	legal {
-		description
 		license_agreement_url
 		privacy_policy_url
+	}
+	linked_resources {
+		title
+		type
+		description
+		url
+	}
+	faqs {
+		answer
+		question
+	}
+	search_aliases {
+		key
+		value
+	}
+	functional_categories
+	features {
+		title
+		description
+	}
+	quick_start_configuration {
+		instructions
 	}
 }
 `

--- a/internal/resource/productlisting.go
+++ b/internal/resource/productlisting.go
@@ -11,17 +11,23 @@ const (
 )
 
 type ProductListing struct {
-	ID             string                      `json:"_id,omitempty"`
-	Name           string                      `json:"name,omitempty"`
-	OrgID          int                         `json:"org_id,omitempty"`
-	LastUpdateDate *time.Time                  `json:"last_update_date,omitempty"`
-	Type           ProductListingType          `json:"type,omitempty" jsonschema:"enum=container stack,enum=traditional application,enum=openstack infra"`
-	Descriptions   *ProductListingDescriptions `json:"descriptions,omitempty"`
-	Contacts       []ProductListingContact     `json:"contacts,omitempty"`
-	CreationDate   *time.Time                  `json:"creation_date,omitempty"`
-	CertProjects   []string                    `json:"cert_projects,omitempty"`
-	Support        *ProductListingSupport      `json:"support,omitempty"`
-	Legal          *ProductListingLegal        `json:"legal,omitempty"`
+	ID                      string                                `json:"_id,omitempty"`
+	Name                    string                                `json:"name,omitempty"`
+	OrgID                   int                                   `json:"org_id,omitempty"`
+	LastUpdateDate          *time.Time                            `json:"last_update_date,omitempty"`
+	Type                    ProductListingType                    `json:"type,omitempty" jsonschema:"enum=container stack,enum=traditional application,enum=openstack infra"`
+	Descriptions            *ProductListingDescriptions           `json:"descriptions,omitempty"`
+	Contacts                []ProductListingContact               `json:"contacts,omitempty" jsonschema:"minItems=1,maxItems=10"`
+	CreationDate            *time.Time                            `json:"creation_date,omitempty"`
+	CertProjects            []string                              `json:"cert_projects,omitempty"`
+	Support                 *ProductListingSupport                `json:"support,omitempty"`
+	Legal                   *ProductListingLegal                  `json:"legal,omitempty"`
+	LinkedResources         []ProductListingLinkedResource        `json:"linked_resources,omitempty" jsonschema:"minItems=3,maxItems=8"`
+	FAQs                    []FAQ                                 `json:"faqs,omitempty"`
+	SearchAliases           []SearchAlias                         `json:"search_aliases,omitempty" jsonschema:"maxItems=5" jsonschema_description:"A collection of key value pairs used assist users searching for your product listing"`
+	FunctionalCategory      []FunctionalCategory                  `json:"functional_categories,omitempty" jsonschema:"minItems=1,maxItems=3,enum=AI/ML,enum=Analytics,enum=App dev,enum=App modernization,enum=Automation,enum=Backup & Recovery,enum=Cloud,enum=Compute,enum=Content management,enum=Data management,enum=Developer tools,enum=DevOps,enum=Edge,enum=Infrastructure,enum=IT & management tools,enum=Migration,enum=Networking,enum=Observability,enum=Orchestration,enum=OS & platforms,enum=Security,enum=Storage,enum=Virtualization"`
+	QuickStartConfiguration ProductListingQuickStartConfiguration `json:"quick_start_configuration,omitempty"`
+	Features                []ProductListingFeature               `json:"features,omitempty"`
 }
 
 func (p *ProductListing) HasName() bool {
@@ -32,28 +38,92 @@ func (p *ProductListing) HasID() bool {
 	return p.ID != ""
 }
 
+type ProductListingQuickStartConfiguration struct {
+	Instructions string `json:"instructions,omitempty" jsonschema:"minLength=1,maxLength=10000" jsonschema_description:"Quick start instructions for your users. Supports HTML formatting."`
+}
+
+type ProductListingFeature struct {
+	Title       string `json:"title,omitempty" jsonschema:"maxLength=60" jsonschema_description:"The title of a supported feature."`
+	Description string `json:"description,omitempty" jsonschema:"maxLength=1000" jsonschema_description:"A description of the titled feature. Supports HTML Formatting."`
+}
+
 type ProductListingSupport struct {
-	Description  string `json:"description,omitempty"`
-	EmailAddress string `json:"email_address,omitempty"`
-	PhoneNumber  string `json:"phone_number,omitempty"`
 	URL          string `json:"url,omitempty"`
+	Description  string `json:"description,omitempty" jsonschema:"minLength=1,maxLength-=500"`
+	EmailAddress string `json:"email_address,omitempty"`
+	PhoneNumber  string `json:"phone_number,omitempty" jsonschema:"minLength=1,maxLength=50"`
 }
 
 type ProductListingLegal struct {
-	Description         string `json:"description,omitempty"`
 	LicenseAgreementURL string `json:"license_agreement_url,omitempty"`
 	PrivacyPolicyURL    string `json:"privacy_policy_url,omitempty"`
 }
 
 type ProductListingDescriptions struct {
 	Long  string `json:"long,omitempty"`
-	Short string `json:"short,omitempty"`
+	Short string `json:"short,omitempty" jsonschema:"minLength=50"`
 }
 
 type ProductListingContact struct {
 	EmailAddress string `json:"email_address,omitempty"`
-	Type         string `json:"type,omitempty"`
+	Type         string `json:"type,omitempty" jsonschema:"enum=Marketing contact,enum=Technical contact"`
 }
+
+type ProductListingLinkedResource struct {
+	Title       string             `json:"title,omitempty"`
+	Description string             `json:"description,omitempty"`
+	Type        LinkedResourceType `json:"type,omitempty" jsonschema:"enum=Video,enum=Article,enum=Documentation,enum=Website,enum=Podcasts,enum=On-demand Events"`
+	URL         string             `json:"url,omitempty"`
+}
+
+type LinkedResourceType = string
+
+const (
+	LinkedResourceTypeVideo         LinkedResourceType = "Video"
+	LinkedResourceTypeArticle       LinkedResourceType = "Article"
+	LinkedResourceTypeDocumentation LinkedResourceType = "Documentation"
+	LinkedResourceTypeWebsite       LinkedResourceType = "Website"
+	LinkedResourceTypePodcasts      LinkedResourceType = "Podcasts"
+	LinkedResourceTypeOnDemandEvent LinkedResourceType = "On-demand Events"
+)
+
+type FAQ struct {
+	Question string `json:"question,omitempty" jsonschema:"maxLength=500" jsonschema_description:"Common questions"`
+	Answer   string `json:"answer,omitempty" jsonschema:"maxLength=10000" jsonschema_description:"Answers to your questions. May contain HTML."`
+}
+
+type SearchAlias struct {
+	Key   string `json:"key,omitempty" jsonschema:"minLength=1,maxLength=50" jsonschema_description:"Acronyms, or short identifiers related to the project. E.g. \"RHEL\""`
+	Value string `json:"value,omitempty" jsonschema:"minLength=1,maxLength=100" jsonschema_description:"Related long-form meaning of the related acronym or short identifier. E.g. \"Red Hat Enterprise Linux\""`
+}
+
+type FunctionalCategory = string
+
+const (
+	FunctionalCategoryAIML              FunctionalCategory = "AI/ML"
+	FunctionalCategoryAnalytics         FunctionalCategory = "Analytics"
+	FunctionalCategoryAppDev            FunctionalCategory = "App dev"
+	FunctionalCategoryAppModernization  FunctionalCategory = "App modernization"
+	FunctionalCategoryAutomation        FunctionalCategory = "Automation"
+	FunctionalCategoryBackupRecovery    FunctionalCategory = "Backup & Recovery"
+	FunctionalCategoryCloud             FunctionalCategory = "Cloud"
+	FunctionalCategoryCompute           FunctionalCategory = "Compute"
+	FunctionalCategoryContentManagement FunctionalCategory = "Content management"
+	FunctionalCategoryDataManagement    FunctionalCategory = "Data management"
+	FunctionalCategoryDeveloperTools    FunctionalCategory = "Developer tools"
+	FunctionalCategoryDevOps            FunctionalCategory = "DevOps"
+	FunctionalCategoryEdge              FunctionalCategory = "Edge"
+	FunctionalCategoryInfrastructure    FunctionalCategory = "Infrastructure"
+	FunctionalCategoryITManagementTools FunctionalCategory = "IT & management tools"
+	FunctionalCategoryMigration         FunctionalCategory = "Migration"
+	FunctionalCategoryNetworking        FunctionalCategory = "Networking"
+	FunctionalCategoryObservability     FunctionalCategory = "Observability"
+	FunctionalCategoryOrchestration     FunctionalCategory = "Orchestration"
+	FunctionalCategoryOSPlatforms       FunctionalCategory = "OS & platforms"
+	FunctionalCategorySecurity          FunctionalCategory = "Security"
+	FunctionalCategoryStorage           FunctionalCategory = "Storage"
+	FunctionalCategoryVirtualization    FunctionalCategory = "Virtualization"
+)
 
 /*
 Below PoC leverages genqlient's generated interface methods and allows us to


### PR DESCRIPTION
This PR adds additional product listing data from the upstream API, and adds some schema-powered validation, with the goal of aligning more closely to the data that a user can populate via the API for Product Listings.

Signed-off-by: Jose R. Gonzalez <komish@flutes.dev>
