### PR TITLE
Add utilities to cleanup product listings or components in one-off scenarios

### DIFF
--- a/internal/cmd/productctl/cmd/archivecomponent/archivecomponent.go
+++ b/internal/cmd/productctl/cmd/archivecomponent/archivecomponent.go
@@ -1,0 +1,70 @@
+package archivecomponent
+
+import (
+	"context"
+
+	"github.com/Khan/genqlient/graphql"
+	"github.com/spf13/cobra"
+
+	"github.com/opdev/productctl/internal/catalogapi"
+	"github.com/opdev/productctl/internal/cli"
+	"github.com/opdev/productctl/internal/genpyxis"
+	"github.com/opdev/productctl/internal/logger"
+)
+
+func Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "archive-component <component-id>",
+		Short: "Archives the component with the specified component ID",
+		Long: `Archives the component with the specified component ID
+
+This should be considered a destructive operation. Note that there are various reasons why the API may reject this operation. Those reasons may need to be handled directly via the Partner Connect UI.`,
+		Args: cobra.MinimumNArgs(1), // The component ID
+		RunE: runE,
+	}
+
+	return cmd
+}
+
+func runE(cmd *cobra.Command, args []string) error {
+	L := logger.FromContextOrDiscard(cmd.Context())
+	_, token, err := cli.EnsureEnv()
+	if err != nil {
+		return err
+	}
+
+	var endpoint string
+	if cmd.Flags().Changed(cli.FlagIDCustomEndpoint) {
+		endpoint, _ = cmd.Flags().GetString(cli.FlagIDCustomEndpoint)
+		L.Debug("custom endpoint set, using it over env value", "endpoint", endpoint)
+	} else {
+		env, _ := cmd.Flags().GetString(cli.FlagIDEndpoint)
+		endpoint, err = cli.ResolveAPIEndpoint(env)
+		if err != nil {
+			return err
+		}
+		L.Debug("endpoint resolved", "endpoint", endpoint)
+	}
+
+	return run(cmd.Context(), args[0], token, endpoint)
+}
+
+func run(ctx context.Context, componentID string, token string, endpoint catalogapi.APIEndpoint) error {
+	L := logger.FromContextOrDiscard(ctx)
+	L.Info("archiving component", "_id", componentID)
+
+	L.Debug("building graphql client")
+	httpClient := catalogapi.TokenAuthenticatedHTTPClient(token, L.With("name", "httpclient"))
+	client := graphql.NewClient(endpoint, httpClient)
+
+	resp, err := genpyxis.ArchiveComponent(ctx, client, componentID)
+	if err != nil {
+		return err
+	}
+
+	if gqlErr := resp.Update_certification_project.GetError(); gqlErr != nil {
+		return catalogapi.ParseGraphQLResponseError(gqlErr)
+	}
+
+	return nil
+}

--- a/internal/cmd/productctl/cmd/cmd.go
+++ b/internal/cmd/productctl/cmd/cmd.go
@@ -9,9 +9,11 @@ import (
 
 	"github.com/opdev/productctl/internal/cli"
 	"github.com/opdev/productctl/internal/cmd/productctl/cmd/apply"
+	"github.com/opdev/productctl/internal/cmd/productctl/cmd/archivecomponent"
 	"github.com/opdev/productctl/internal/cmd/productctl/cmd/bridge"
 	"github.com/opdev/productctl/internal/cmd/productctl/cmd/cleanup"
 	"github.com/opdev/productctl/internal/cmd/productctl/cmd/create"
+	"github.com/opdev/productctl/internal/cmd/productctl/cmd/deleteproductlisting"
 	"github.com/opdev/productctl/internal/cmd/productctl/cmd/fetch"
 	"github.com/opdev/productctl/internal/cmd/productctl/cmd/jsonschema"
 	"github.com/opdev/productctl/internal/cmd/productctl/cmd/sanitize"
@@ -35,6 +37,13 @@ func RootCmd() *cobra.Command {
 
 	cmd.AddCommand(version.Command())
 	cmd.PersistentFlags().String(cli.FlagIDLogLevel, "info", "The verbosity of the tool itself. Ex. error, warn, info, debug")
+
+	util := bridge.Command("util", "Utilities for the management of your Partner Connect account")
+	util.PersistentFlags().String(cli.FlagIDEndpoint, "prod", "The catalog API environment to use. Choose from stage, prod")
+	util.PersistentFlags().String(cli.FlagIDCustomEndpoint, "", "Define a custom API endpoint. Supersedes predefined environment values like \"prod\" if set")
+	util.AddCommand(archivecomponent.Command())
+	util.AddCommand(deleteproductlisting.Command())
+	cmd.AddCommand(util)
 
 	// Build the product management command tree.
 	product := bridge.Command("product", "Manage your Product Listing")

--- a/internal/cmd/productctl/cmd/deleteproductlisting/deleteproductlisting.go
+++ b/internal/cmd/productctl/cmd/deleteproductlisting/deleteproductlisting.go
@@ -1,0 +1,72 @@
+package deleteproductlisting
+
+import (
+	"context"
+
+	"github.com/Khan/genqlient/graphql"
+	"github.com/spf13/cobra"
+
+	"github.com/opdev/productctl/internal/catalogapi"
+	"github.com/opdev/productctl/internal/cli"
+	"github.com/opdev/productctl/internal/genpyxis"
+	"github.com/opdev/productctl/internal/logger"
+)
+
+func Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete-productlisting <productID>",
+		Short: "Deletes the product listingwith the specified product ID.",
+		Long: `Deletes the product listing with the specified product ID
+
+This should be considered a destructive operation. Note that there are various reasons why the API may reject this operation. Those reasons may need to be handled directly via the Partner Connect UI.
+`,
+		Args: cobra.MinimumNArgs(1), // The product ID
+		RunE: runE,
+	}
+
+	return cmd
+}
+
+func runE(cmd *cobra.Command, args []string) error {
+	L := logger.FromContextOrDiscard(cmd.Context())
+	_, token, err := cli.EnsureEnv()
+	if err != nil {
+		return err
+	}
+
+	var endpoint string
+	if cmd.Flags().Changed(cli.FlagIDCustomEndpoint) {
+		endpoint, _ = cmd.Flags().GetString(cli.FlagIDCustomEndpoint)
+		L.Debug("custom endpoint set, using it over env value", "endpoint", endpoint)
+	} else {
+		env, _ := cmd.Flags().GetString(cli.FlagIDEndpoint)
+		endpoint, err = cli.ResolveAPIEndpoint(env)
+		if err != nil {
+			return err
+		}
+		L.Debug("endpoint resolved", "endpoint", endpoint)
+	}
+
+	return run(cmd.Context(), args[0], token, endpoint)
+}
+
+func run(ctx context.Context, listingID string, token string, endpoint catalogapi.APIEndpoint) error {
+	L := logger.FromContextOrDiscard(ctx)
+	L.Info("deleting product listing", "_id", listingID)
+
+	L.Debug("building graphql client")
+	httpClient := catalogapi.TokenAuthenticatedHTTPClient(token, L.With("name", "httpclient"))
+	client := graphql.NewClient(endpoint, httpClient)
+
+	resp, err := genpyxis.DeleteProduct(ctx, client, listingID)
+	if err != nil {
+		return err
+	}
+
+	if gqlErr := resp.Update_product_listing.GetError(); gqlErr != nil {
+		return catalogapi.ParseGraphQLResponseError(gqlErr)
+	}
+
+	L.Info("done")
+	return nil
+}

--- a/internal/cmd/productctl/cmd/fetch/fetch.go
+++ b/internal/cmd/productctl/cmd/fetch/fetch.go
@@ -2,7 +2,6 @@
 package fetch
 
 import (
-	"context"
 	"fmt"
 	"os"
 
@@ -19,9 +18,14 @@ func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "fetch <productID>",
 		Short: "Get a pre-existing product listing",
-		Long:  "Get data about a pre-existing product listing by its ID and generate its declaration for storage on disk.",
-		Args:  cobra.MinimumNArgs(1),
-		RunE:  getProductListingRunE,
+		Long: `Get data about a pre-existing product listing by its ID and generate its declaration for storage on disk.
+
+Only components attached to this product listing with an "active" status will be returned.
+
+This command does not overwrite an existing file, and relies in output redirection to store the contents to disk at any location you would prefer.
+`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: getProductListingRunE,
 	}
 
 	return cmd
@@ -49,11 +53,10 @@ func getProductListingRunE(cmd *cobra.Command, args []string) error {
 		L.Debug("endpoint resolved", "endpoint", endpoint)
 	}
 
-	ctx := context.Background()
 	httpClient := catalogapi.TokenAuthenticatedHTTPClient(token, L.With("name", "httpclient"))
 	client := graphql.NewClient(endpoint, httpClient)
 
-	newListing, err := catalogapi.PopulateProduct(ctx, client, productID)
+	newListing, err := catalogapi.PopulateProduct(cmd.Context(), client, productID)
 	if err != nil {
 		return err
 	}

--- a/internal/genpyxis/generated.go
+++ b/internal/genpyxis/generated.go
@@ -2726,7 +2726,7 @@ func ArchiveComponent(
 // The query or mutation executed by ComponentsForListing.
 const ComponentsForListing_Operation = `
 query ComponentsForListing ($productID: ObjectIDFilterScalar, $page: Int!, $pageSize: Int!) {
-	find_product_listing_certification_projects(id: $productID, page: $page, page_size: $pageSize) {
+	find_product_listing_certification_projects(id: $productID, page: $page, page_size: $pageSize, filter: {project_status:{eq:"active"}}) {
 		data {
 			... ComponentSupportedFields
 		}

--- a/internal/genpyxis/queries.graphql
+++ b/internal/genpyxis/queries.graphql
@@ -112,6 +112,7 @@ query ComponentsForListing(
     id: $productID
     page: $page
     page_size: $pageSize
+    filter: {project_status: {eq: "active"}}
   ) {
     # @genqlient(flatten: true)
     data {


### PR DESCRIPTION
This PR adds the *delete-productlisting* and *archive-component* subcommands.

These commands take individual IDs and do not execute any additional operations other than
toggling the project_status to "archived" (components), and the deleted value to "true" (product listings).

In doing this work, I noticed an error in how product listings are represented on disk. Specifically
product listings would reflect archived components within their cert_project lists. For this reason,
logic has been implemented to replace the value of that field with only the value coming from the call
to receive all active components tied to the listing.

Logs are emitted at the "debug" log-level to capture the replacement.

Signed-off-by: Jose R. Gonzalez <komish@flutes.dev>
