### PR TITLE
Add support for updated discovery.json

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/invopop/jsonschema v0.13.0
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/onsi/gomega v1.37.0
-	github.com/opdev/discover-workload v0.0.0-20250115205614-3233d42da6d9
+	github.com/opdev/discover-workload v0.0.0-20250613205600-4f6ee215f625
 	github.com/spf13/cobra v1.9.1
 	sigs.k8s.io/yaml v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/onsi/ginkgo/v2 v2.23.4 h1:ktYTpKJAVZnDT4VjxSbiBenUjmlL/5QkBEocaWXiQus
 github.com/onsi/ginkgo/v2 v2.23.4/go.mod h1:Bt66ApGPBFzHyR+JO10Zbt0Gsp4uWxu5mIOTusL46e8=
 github.com/onsi/gomega v1.37.0 h1:CdEG8g0S133B4OswTDC/5XPSzE1OeP29QOioj2PID2Y=
 github.com/onsi/gomega v1.37.0/go.mod h1:8D9+Txp43QWKhM24yyOBEdpkzN8FvJyAwecBgsU4KU0=
-github.com/opdev/discover-workload v0.0.0-20250115205614-3233d42da6d9 h1:sLy7Kdnp5w+0GVQ6rYjLTpGR+kUCarfFnPcolLqJTKo=
-github.com/opdev/discover-workload v0.0.0-20250115205614-3233d42da6d9/go.mod h1:pYjtJEWZgLGKOM1/4aCxHVf297u00qJN/KMNN9uWMtM=
+github.com/opdev/discover-workload v0.0.0-20250613205600-4f6ee215f625 h1:kIvS4Q0WQJOg/TXGr7Web+krA9SZsINe8CUZ27zoF98=
+github.com/opdev/discover-workload v0.0.0-20250613205600-4f6ee215f625/go.mod h1:Evlxr5q2psdSnx1Fdf0WJouLvcXlGyETN5hdaDLh8Fo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=

--- a/internal/cmd/productctl/cmd/testutils/testdata/fixture.minimal.discovery.json
+++ b/internal/cmd/productctl/cmd/testutils/testdata/fixture.minimal.discovery.json
@@ -1,9 +1,17 @@
 {
     "DiscoveredImages": [
         {
-            "PodName": "pod-1",
-            "ContainerName": "container-1",
-            "Image": "example.com/registry/namespace:tag"
+            "Image": "example.com/registry/namespace:tag",
+            "Containers": [
+                {
+                    "Name": "container-1",
+                    "Type": "Container",
+                    "Pod": {
+                        "Name": "pod-1",
+                        "Namespace": "examplens"
+                    }
+                }
+            ]
         }
     ]
 }

--- a/internal/discovery/discover_internal_test.go
+++ b/internal/discovery/discover_internal_test.go
@@ -1,0 +1,52 @@
+package discovery
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	discoverworkload "github.com/opdev/discover-workload/discovery"
+)
+
+var _ = Describe("Discovery (internal)", func() {
+	When("determining the most frequent container name in a container list", func() {
+		var containers []discoverworkload.DiscoveredContainer
+
+		When("there one name present in the list is used more than onee", func() {
+			BeforeEach(func() {
+				containers = []discoverworkload.DiscoveredContainer{
+					{Name: "container-1"},
+					{Name: "container-1"},
+					{Name: "container-2"},
+				}
+			})
+
+			It("should return the container name with the larger count", func() {
+				actual, count, err := mostFrequentName(containers)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(count).To(Equal(2))
+				Expect(actual).To(Equal("container-1"))
+			})
+		})
+		When("there are no containers", func() {
+			BeforeEach(func() {
+				containers = []discoverworkload.DiscoveredContainer{}
+			})
+			It("should return the expected error", func() {
+				_, _, err := mostFrequentName(containers)
+				Expect(err).To(MatchError(ErrNoContainers))
+			})
+		})
+
+		When("the containers input has malformed data", func() {
+			BeforeEach(func() {
+				containers = []discoverworkload.DiscoveredContainer{
+					{Name: ""},
+				}
+			})
+			It("should return the expected error", func() {
+				_, _, err := mostFrequentName(containers)
+				Expect(err).To(MatchError(ErrCountingContainerNameOccurrences))
+			})
+		})
+	})
+})

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -11,6 +11,14 @@ import (
 
 var _ = Describe("Discovery", func() {
 	When("converting workload discovery manifest to component resources", func() {
+		It("should return an error if there are images with malformed container data", func() {
+			_, err := libdiscovery.ComponentsFromDiscoveryManifest(discovery.Manifest{
+				DiscoveredImages: []discovery.DiscoveredImage{
+					{Containers: []discovery.DiscoveredContainer{}},
+				},
+			})
+			Expect(err).To(MatchError(libdiscovery.ErrNoContainers))
+		})
 		It("should return an error when discovery manifest contains no entries", func() {
 			_, err := libdiscovery.ComponentsFromDiscoveryManifest(discovery.Manifest{})
 			Expect(err).To(MatchError(libdiscovery.ErrNoImagesDiscovered))
@@ -19,8 +27,8 @@ var _ = Describe("Discovery", func() {
 		It("should return an error for duplicate component names", func() {
 			manifestWithDuplicateNames := discovery.Manifest{
 				DiscoveredImages: []discovery.DiscoveredImage{
-					{ContainerName: "component1"},
-					{ContainerName: "component1"},
+					{Containers: []discovery.DiscoveredContainer{{Name: "component1"}}},
+					{Containers: []discovery.DiscoveredContainer{{Name: "component1"}}},
 				},
 			}
 			_, err := libdiscovery.ComponentsFromDiscoveryManifest(manifestWithDuplicateNames)
@@ -30,8 +38,8 @@ var _ = Describe("Discovery", func() {
 		It("should return components for valid manifest", func() {
 			manifest := discovery.Manifest{
 				DiscoveredImages: []discovery.DiscoveredImage{
-					{ContainerName: "component1"},
-					{ContainerName: "component2"},
+					{Containers: []discovery.DiscoveredContainer{{Name: "component1"}}},
+					{Containers: []discovery.DiscoveredContainer{{Name: "component2"}}},
 				},
 			}
 			components, err := libdiscovery.ComponentsFromDiscoveryManifest(manifest)


### PR DESCRIPTION
This PR adds support for discover-workload's new discovery.json schema, which supports multiple container workloads referring to the same image.

This pull request also introduces simple logic to try and extract the "most likely container name" to stage as the component's name in the scaffolded product listing.

In the future, we may consider an interactive component here where a user could potentially choose one in real-time, but for now. this will just populate the product listing with the most common name, or the first name (if all names are equally common).

Signed-off-by: Jose R. Gonzalez <komish@flutes.dev>
