### PR TITLE
Label PRs which modify generated schema and code

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,5 @@
+schema-update:
+  - all:
+    - base-branch: 'main'
+    - changed-files:
+      - any-glob-to-any-file: 'internal/genpyxis/{schema.graphql,generated.go}'

--- a/.github/workflows/label-pull-request.yaml
+++ b/.github/workflows/label-pull-request.yaml
@@ -1,0 +1,18 @@
+name: Label pull request
+
+on:
+  pull_request_target:
+    branches:
+      - main
+
+jobs:
+  labeler:
+    name: Apply labels
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          sync-labels: true


### PR DESCRIPTION
The intent here is that PRs which modify the outputs of `make generate` (`internal/genpyxis/schema.graphql`, `internal/genpyxis/generated.go`) should be labeled with a `schema-update` label.

This is needed to schedule PRs for updating schema, to ensure that there is no existing PR making this change before attempting to create a new one.