### PR TITLE
Upgrade to golangci-lint v2

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,48 +1,66 @@
-run:
-  # Default timeout is 1m, up to give more room
-  timeout: 4m
+version: "2"
+output:
+  formats:
+    tab:
+      path: stdout
+      colors: false
 linters:
   enable:
     - asciicheck
-    - unused
     - depguard
-    - gofumpt
-    - goimports
-    # - importas
-    - revive
     - misspell
-    - stylecheck
+    - revive
+    - staticcheck
     - tparallel
     - unconvert
     - unparam
     - whitespace
-linters-settings:
-  revive:
+  settings:
+    depguard:
+      rules:
+        main:
+          list-mode: lax
+          deny:
+            - pkg: gopkg.in/yaml
+              desc: use sigs.k8s.io/yaml
+            - pkg: github.com/hasura/go-graphql-client
+              desc: use github.com/Khan/genqlient[/graphql]
+            - pkg: github.com/shurcooL/graphql
+              desc: use github.com/Khan/genqlient[/graphql]
+    revive:
+      rules:
+        - name: dot-imports
+          arguments:
+            - allowedPackages:
+                - github.com/onsi/gomega
+                - github.com/onsi/ginkgo
+                - github.com/onsi/ginkgo/v2
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
     rules:
-      - name: dot-imports
-        arguments:
-        - allowedPackages:
-          - github.com/onsi/gomega
-          - github.com/onsi/ginkgo
-          - github.com/onsi/ginkgo/v2
-  goimports:
-    local-prefixes: github.com/opdev/productctl
-  depguard:
-    rules:
-      main:
-        list-mode: lax
-        deny:
-        - pkg: "gopkg.in/yaml"
-          desc: "use sigs.k8s.io/yaml"
-        - pkg: "github.com/hasura/go-graphql-client"
-          desc: "use github.com/Khan/genqlient[/graphql]"
-        - pkg: "github.com/shurcooL/graphql"
-          desc: "use github.com/Khan/genqlient[/graphql]"
-issues:
-  exclude-rules:
-  - path: _test.go
-    linters:
-      - errcheck
-output:
-  formats:
-    - format: tab
+      - linters:
+          - errcheck
+        path: _test.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/opdev/productctl
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -105,9 +105,9 @@ install.gofumpt:
 
 # golangci-lint
 GOLANGCI_LINT = $(OUT_DIR)/golangci-lint
-GOLANGCI_LINT_VERSION ?= v1.63.4
+GOLANGCI_LINT_VERSION ?= v2.1.6
 install.golangci-lint:
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION))
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION))
 
 # genqlient
 GENQLIENT = $(OUT_DIR)/genqlient

--- a/internal/catalogapi/catalogapi.go
+++ b/internal/catalogapi/catalogapi.go
@@ -38,11 +38,7 @@ func ApplyProduct(
 ) (*resource.ProductListingDeclaration, error) {
 	L := logger.FromContextOrDiscard(ctx)
 
-	updateListing := false
-
-	if declaration.Spec.HasID() {
-		updateListing = true
-	}
+	updateListing := declaration.Spec.HasID()
 
 	if !declaration.Spec.HasName() {
 		return nil, ErrMissingName


### PR DESCRIPTION
Small change in code to respond to a lint error. If desired, we can add an exception here instead.