### PR TITLE
Add release category for container components

### DIFF
--- a/internal/resource/component_container.go
+++ b/internal/resource/component_container.go
@@ -9,6 +9,7 @@ type ContainerComponent struct {
 	Repository            string                        `json:"repository,omitempty"`
 	RepositoryDescription string                        `json:"repository_description,omitempty"`
 	RepositoryName        string                        `json:"repository_name,omitempty"`
+	ReleaseCategories     []ReleaseCategory             `json:"release_categories,omitempty" jsonschema:"enum=Generally Available,enum=Beta"`
 	ShortDescription      string                        `json:"short_description,omitempty"`
 	SupportPlatforms      []string                      `json:"support_platforms,omitempty"`
 	Type                  ContainerComponentType        `json:"type,omitempty" jsonschema:"enum=container,enum=operator bundle image"`
@@ -39,4 +40,11 @@ const (
 	ContentTypeUBI            ContainerComponentContentType = "Red Hat Universal Base Image (UBI)"
 	ContentTypeOperatorBundle ContainerComponentContentType = "Operator Bundle Image"
 	ContentTypeScratch        ContainerComponentContentType = "Scratch Image"
+)
+
+type ReleaseCategory string
+
+const (
+	ReleaseCategoryGA   ReleaseCategory = "Generally Available"
+	ReleaseCategoryBeta ReleaseCategory = "Beta"
 )


### PR DESCRIPTION
Adding release_categories. Worth noting that the API includes "Tech Preview" as an option, but the Connect UI does not, so for now, it's not included as an enumeration in jsonschema markers.

Signed-off-by: Jose R. Gonzalez <komish@flutes.dev>
