### PR TITLE
Add -trimpath flag and -s -w ldflags on builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,9 @@ BIN_COMMIT  = $(shell git rev-parse HEAD)
 bin:
 	CGO_ENABLED=0 go build \
 		-o $(BIN_FILE) \
+		-trimpath \
 		-ldflags "\
+			-s -w \
 			-X github.com/opdev/productctl/internal/version.commit=$(BIN_COMMIT) \
 			-X github.com/opdev/productctl/internal/version.version=$(BIN_VERSION)" \
 		./internal/cmd/productctl


### PR DESCRIPTION
| Platform | Before | After |
| --- | --- | --- |
| linux/amd64 | 12 MiB | 7.8 MiB |
| linux/arm64 | 11 MiB | 7.4 MiB |
| linux/ppc64le | 11 MiB | 7.7 MiB |
| linux/s390x | 12 MiB | 8.3 MiB |
| darwin/amd64 | 12 MiB | 8 MiB |
| darwin/arm64 | 11 MiB | 7.6 MiB |

Similar change to https://github.com/redhat-openshift-ecosystem/openshift-preflight/pull/1281.