### PR TITLE
Explicitly add schema-update label on PR creation

### DIFF
--- a/.github/workflows/schema-update.yaml
+++ b/.github/workflows/schema-update.yaml
@@ -55,6 +55,7 @@ jobs:
 
             gh pr create --repo "${GITHUB_REPOSITORY}" \
                          --title "Update generated schema and code for Pyxis" \
+                         --label schema-update \
                          --body "${PR_BODY}" \
                          --base "${BASE_BRANCH}" \
                          --head "pyxis-schema-update-${timestamp}"


### PR DESCRIPTION
This fixes an issue where multiple schema update PRs (generated by CI) are in flight at once.

The Labeler configuration should be labeling these, but isn't because the PR is CI generated. That's an implicit behavior of GitHub actions and is expected. I'll leave the labeler in place for now, but this change should fix the issue.